### PR TITLE
Ensure real valued eigenvectors/-values if possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Other changes:
-- moved to package to src directory
+- Moved to package to src directory
+- Add `nvals` parameter to all eigenvalues/-vectors functions
+- Add `ntimescales` parameter to `implied_timescales`
+- Improved tests for `implied_timescales`
+
+### Bugfix 🐛:
+- Fix complex matrices for LumpedStateTraj due to complex eigenvalues
 
 ## [0.6.1] - 2022-08-01
 ### Bugfix 🐛:

--- a/src/msmhelper/linalg.py
+++ b/src/msmhelper/linalg.py
@@ -13,7 +13,7 @@ from msmhelper import tests
 
 
 @decorit.alias('eigl')
-def left_eigenvectors(matrix):
+def left_eigenvectors(matrix, nvals=None):
     """Estimate left eigenvectors.
 
     Estimates the left eigenvectors and corresponding eigenvalues of a
@@ -24,6 +24,10 @@ def left_eigenvectors(matrix):
     matrix : ndarray
         Quadratic 2d matrix eigenvectors and eigenvalues or determined of.
 
+    nvals : int, optional
+        Number of returned eigenvalues and -vectors. Using ensures probability
+        of real valued matrices.
+
     Returns
     -------
     eigenvalues : ndarray
@@ -34,15 +38,11 @@ def left_eigenvectors(matrix):
 
     """
     matrix = np.asarray(matrix)
-    if not tests.is_quadratic(matrix):
-        raise TypeError('Matrix needs to be quadratic {0}'.format(matrix))
-
-    eigenvalues, eigenvectors = _eigenvectors(matrix.transpose())
-    return np.real_if_close(eigenvalues), np.real_if_close(eigenvectors)
+    return _eigenvectors(matrix.transpose(), nvals)
 
 
 @decorit.alias('eig')
-def right_eigenvectors(matrix):
+def right_eigenvectors(matrix, nvals=None):
     """Estimate right eigenvectors.
 
     Estimates the right eigenvectors and corresponding eigenvalues of a
@@ -53,6 +53,10 @@ def right_eigenvectors(matrix):
     matrix : ndarray
         Quadratic 2d matrix eigenvectors and eigenvalues or determined of.
 
+    nvals : int, optional
+        Number of returned eigenvalues and -vectors. Using ensures probability
+        of real valued matrices.
+
     Returns
     -------
     eigenvalues : ndarray
@@ -63,28 +67,38 @@ def right_eigenvectors(matrix):
 
     """
     matrix = np.asarray(matrix)
+    return _eigenvectors(matrix, nvals)
+
+
+def _eigenvectors(matrix, nvals):
+    """Estimate eigenvectors."""
     if not tests.is_quadratic(matrix):
         raise TypeError('Matrix needs to be quadratic {0}'.format(matrix))
 
-    eigenvalues, eigenvectors = _eigenvectors(matrix)
-    return np.real_if_close(eigenvalues), np.real_if_close(eigenvectors)
+    if nvals is None:
+        nvals = len(matrix)
+    elif nvals > len(matrix):
+        raise TypeError(
+            '{nvals} eigenvalues requested but '.format(nvals=nvals) +
+            'matrix of dimension {dim}'.format(dim=len(matrix))
+        )
 
-
-def _eigenvectors(matrix):
-    """Estimate eigenvectors."""
     eigenvalues, eigenvectors = np.linalg.eig(matrix)
 
-    # Transpose eigenvectors, since v[:,i] is eigenvector
+    # Transpose eigenvectors, since v[:, i] is eigenvector
     eigenvectors = eigenvectors.T
 
     # Sort them by descending eigenvalues
     idx_eigenvalues = eigenvalues.argsort()[::-1]
 
-    return eigenvalues[idx_eigenvalues], eigenvectors[idx_eigenvalues]
+    return (
+        np.real_if_close(eigenvalues[idx_eigenvalues][:nvals]),
+        np.real_if_close(eigenvectors[idx_eigenvalues][:nvals]),
+    )
 
 
 @decorit.alias('eiglvals')
-def left_eigenvalues(matrix):
+def left_eigenvalues(matrix, nvals=None):
     """Estimate left eigenvalues.
 
     Estimates the left eigenvalues of a quadratic matrix.
@@ -94,6 +108,10 @@ def left_eigenvalues(matrix):
     matrix : ndarray
         Quadratic 2d matrix eigenvalues or determined of.
 
+    nvals : int, optional
+        Number of returned eigenvalues and -vectors. Using ensures probability
+        of real valued matrices.
+
     Returns
     -------
     eigenvalues : ndarray
@@ -101,14 +119,11 @@ def left_eigenvalues(matrix):
 
     """
     matrix = np.asarray(matrix)
-    if not tests.is_quadratic(matrix):
-        raise TypeError('Matrix needs to be quadratic {0}'.format(matrix))
-
-    return np.real_if_close(_eigenvalues(np.transpose(matrix)))
+    return _eigenvalues(np.transpose(matrix), nvals)
 
 
 @decorit.alias('eigvals')
-def right_eigenvalues(matrix):
+def right_eigenvalues(matrix, nvals=None):
     """Estimate right eigenvalues.
 
     Estimates the right eigenvalues of a quadratic matrix.
@@ -118,6 +133,10 @@ def right_eigenvalues(matrix):
     matrix : ndarray
         Quadratic 2d matrix eigenvalues or determined of.
 
+    nvals : int, optional
+        Number of returned eigenvalues and -vectors. Using ensures probability
+        of real valued matrices.
+
     Returns
     -------
     eigenvalues : ndarray
@@ -125,17 +144,9 @@ def right_eigenvalues(matrix):
 
     """
     matrix = np.asarray(matrix)
-    if not tests.is_quadratic(matrix):
-        raise TypeError('Matrix needs to be quadratic {0}'.format(matrix))
-
-    return np.real_if_close(_eigenvalues(matrix))
+    return _eigenvalues(matrix, nvals)
 
 
-def _eigenvalues(matrix):
+def _eigenvalues(matrix, nvals):
     """Estimate eigenvalues."""
-    eigenvalues = np.linalg.eigvals(matrix)
-
-    # Sort them by descending eigenvalues
-    idx_eigenvalues = eigenvalues.argsort()[::-1]
-
-    return eigenvalues[idx_eigenvalues]
+    return _eigenvectors(matrix, nvals)[0]

--- a/src/msmhelper/msm.py
+++ b/src/msmhelper/msm.py
@@ -178,7 +178,9 @@ def implied_timescales(trajs, lagtimes, ntimescales=None, reversible=False):
     if not (lagtimes > 0).all():
         raise TypeError('Lagtimes needs to be positive integers')
     if reversible:
-        raise TypeError('Reversible matrices are not anymore supported.')
+        raise NotImplementedError(
+            'Reversible matrices are not anymore supported.'
+        )
 
     if ntimescales is None:
         ntimescales = trajs.nstates - 1

--- a/test/test_msm.py
+++ b/test/test_msm.py
@@ -103,7 +103,7 @@ def test__implied_timescales(transmat, lagtime, result):
         [1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 1],
         [1, 2],
         {'ntimescales': 1},
-        [-1 / np.log([2 / 3])],
+        [-1 / np.log([2 / 3]), -2 / np.log([7 / 15])],
         None,
     ),
     (

--- a/test/test_msm.py
+++ b/test/test_msm.py
@@ -86,26 +86,56 @@ def test__estimate_markov_model(traj, lagtime, Tref, statesref):
 ])
 def test__implied_timescales(transmat, lagtime, result):
     """Test implied timescale."""
-    impl = msm._implied_timescales(transmat, lagtime)
+    ntimescales = len(result)
+    impl = msm._implied_timescales(transmat, lagtime, ntimescales=ntimescales)
     np.testing.assert_array_almost_equal(impl, result)
 
 
-@pytest.mark.parametrize('trajs, lagtimes, result', [
-    ([1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 1], [1, 2],
-     [-1 / np.log([2 / 3]), -2 / np.log([7 / 15])])])
-def test_implied_timescales(trajs, lagtimes, result):
+@pytest.mark.parametrize('trajs, lagtimes, kwargs, result, error', [
+    (
+        [1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 1],
+        [1, 2],
+        {},
+        [-1 / np.log([2 / 3]), -2 / np.log([7 / 15])],
+        None,
+    ),
+    (
+        [1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 1],
+        [1, 2],
+        {'ntimescales': 1},
+        [-1 / np.log([2 / 3])],
+        None,
+    ),
+    (
+        [1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 1],
+        [-1, 2],
+        {},
+        None,
+        TypeError,
+    ),
+    (
+        [1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 1],
+        [1, 2.3],
+        {},
+        None,
+        TypeError,
+    ),
+    (
+        [1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 1],
+        [1, 2],
+        {'reversible': True},
+        None,
+        NotImplementedError,
+    ),
+])
+def test_implied_timescales(trajs, lagtimes, kwargs, result, error):
     """Test implied timescale."""
-    impl = msmhelper.implied_timescales(trajs, lagtimes)
-    np.testing.assert_array_almost_equal(impl, result)
-
-    with pytest.raises(TypeError):
-        impl = msmhelper.implied_timescales(trajs, [-1, 2])
-
-    with pytest.raises(TypeError):
-        impl = msmhelper.implied_timescales(trajs, [1, 2.3])
-
-    with pytest.raises(TypeError):
-        impl = msmhelper.implied_timescales(trajs, lagtimes, reversible=True)
+    if error is None:
+        impl = msmhelper.implied_timescales(trajs, lagtimes, **kwargs)
+        np.testing.assert_array_almost_equal(impl, result)
+    else:
+        with pytest.raises(error):
+            impl = msmhelper.implied_timescales(trajs, lagtimes, **kwargs)
 
 
 @pytest.mark.parametrize('tmat, peqref, kwargs, error', [


### PR DESCRIPTION
Ensure real values eigenvectors and eigenvalues if possible. Having a matrix of high dimension  the last few eigenvectors are usually complex due to precision errors. Returning only first `nvals` allows to use `np.real_if_close` to result in real values if possible.