### PR TITLE
Rewrite StateTraj API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Moved all functions related to msm to `msm` module
   - Moved all functions related to raw state trajectories to `md` module
   - Moved all remaing functions into `utils` module
+- Removed `StateTraj.trajs` property to reduce confusion between index and
+  state trajectories.
 - Removed Python 3.6 support.
 
 ### Added Features and Improvements 🙌:

--- a/src/msmhelper/md/corrections.py
+++ b/src/msmhelper/md/corrections.py
@@ -65,9 +65,9 @@ def dynamical_coring(trajs, lagtime, iterative=True):
 
     # convert trajs to numba list # noqa: SC100
     if numba.config.DISABLE_JIT:
-        cored_trajs = trajs.state_trajs
+        cored_trajs = trajs.trajs
     else:  # pragma: no cover
-        cored_trajs = numba.typed.List(trajs.state_trajs)
+        cored_trajs = numba.typed.List(trajs.trajs)
 
     if lagtime <= 0:
         raise ValueError('The lagtime should be greater 0.')

--- a/src/msmhelper/msm/msm.py
+++ b/src/msmhelper/msm/msm.py
@@ -37,20 +37,7 @@ def estimate_markov_model(trajs, lagtime):
 
     """
     trajs = StateTraj(trajs)
-
-    if isinstance(trajs, LumpedStateTraj):
-        return _estimate_markov_model(
-            trajs.trajs,
-            lagtime,
-            trajs.nmicrostates,
-            trajs.microstates,
-        )
-    return _estimate_markov_model(
-        trajs.trajs,
-        lagtime,
-        trajs.nstates,
-        trajs.states,
-    )
+    return trajs.estimate_markov_model(lagtime)
 
 
 def _estimate_markov_model(trajs, lagtime, nstates, perm=None):

--- a/src/msmhelper/msm/msm.py
+++ b/src/msmhelper/msm/msm.py
@@ -12,7 +12,7 @@ import numpy as np
 
 from msmhelper.utils import tests
 from msmhelper.msm.utils import linalg
-from msmhelper.statetraj import LumpedStateTraj, StateTraj
+from msmhelper.statetraj import StateTraj
 
 
 def estimate_markov_model(trajs, lagtime):

--- a/src/msmhelper/statetraj.py
+++ b/src/msmhelper/statetraj.py
@@ -100,7 +100,7 @@ class StateTraj:  # noqa: WPS214
         return np.sum([len(traj) for traj in self._trajs])
 
     @property
-    def state_trajs(self):
+    def trajs(self):
         """Return state trajectory.
 
         Returns
@@ -109,6 +109,8 @@ class StateTraj:  # noqa: WPS214
             List of ndarrays holding the input data.
 
         """
+        if np.array_equal(self.states, np.arange(1, self.nstates + 1)):
+            return [traj + 1 for traj in self._trajs]
         if np.array_equal(self.states, np.arange(self.nstates)):
             return self._trajs
         return mh.shift_data(
@@ -118,22 +120,20 @@ class StateTraj:  # noqa: WPS214
         )
 
     @property
-    def state_trajs_flatten(self):
+    def trajs_flatten(self):
         """Return flattened state trajectory.
 
         Returns
         -------
         trajs : ndarray
-            1D ndarrays representation of state trajectories.
+            1D ndarray representation of state trajectories.
 
         """
-        return np.concatenate(self.state_trajs)
+        return np.concatenate(self.trajs)
 
     @property
     def index_trajs(self):
         """Return index trajectory.
-
-        Same as `self.trajs`
 
         Returns
         -------
@@ -143,21 +143,33 @@ class StateTraj:  # noqa: WPS214
         """
         return self._trajs
 
+    @property
+    def index_trajs_flatten(self):
+        """Return flattened index trajectory.
+
+        Returns
+        -------
+        trajs : ndarray
+            1D ndarray representation of index trajectories.
+
+        """
+        return np.concatenate(self.index_trajs)
+
     def __repr__(self):
         """Return representation of class."""
         kw = {
             'classname': self.__class__.__name__,
-            'trajs': self.state_trajs,
+            'trajs': self.trajs,
         }
         return ('{classname}({trajs})'.format(**kw))
 
     def __str__(self):
         """Return string representation of class."""
-        return ('{trajs!s}'.format(trajs=self.state_trajs))
+        return ('{trajs!s}'.format(trajs=self.trajs))
 
     def __iter__(self):
         """Iterate over trajectories."""
-        return iter(self.state_trajs)
+        return iter(self.trajs)
 
     def __len__(self):
         """Return length of list of trajectories."""
@@ -165,7 +177,7 @@ class StateTraj:  # noqa: WPS214
 
     def __getitem__(self, key):
         """Get key value."""
-        return self.state_trajs.__getitem__(key)  # noqa: WPS609
+        return self.trajs.__getitem__(key)  # noqa: WPS609
 
     def __eq__(self, other):
         """Compare two objects."""

--- a/src/msmhelper/statetraj.py
+++ b/src/msmhelper/statetraj.py
@@ -13,8 +13,8 @@ import msmhelper as mh
 
 class StateTraj:  # noqa: WPS214
     """Class for handling discrete state trajectories."""
-
     __slots__ = ('_trajs', '_states')
+
     def __new__(cls, trajs):
         """Initialize new instance.
 

--- a/src/msmhelper/statetraj.py
+++ b/src/msmhelper/statetraj.py
@@ -28,7 +28,7 @@ class StateTraj:  # noqa: WPS214
     def __init__(self, trajs):
         """Initialize StateTraj and convert to index trajectories.
 
-        If called with StateTraj instance, it will be retuned instead.
+        If called with StateTraj instance, it will be returned instead.
 
         Parameters
         ----------
@@ -39,7 +39,20 @@ class StateTraj:  # noqa: WPS214
         if isinstance(trajs, StateTraj):
             return
 
-        self.state_trajs = trajs
+        self._trajs = mh.utils.format_state_traj(trajs)
+
+        # get number of states
+        self._states = mh.utils.unique(self._trajs)
+
+        # shift to indices
+        if not np.array_equal(self._states, np.arange(self.nstates)):
+            self._trajs, self._states = mh.utils.rename_by_index(
+                self._trajs,
+                return_permutation=True,
+            )
+
+        # set number of frames
+        self._nframes = np.sum([len(traj) for traj in self.trajs])
 
     @property
     def states(self):
@@ -79,7 +92,7 @@ class StateTraj:  # noqa: WPS214
 
     @property
     def nframes(self):
-        """Return cummulated length of all trajectories.
+        """Return cumulative length of all trajectories.
 
         Returns
         -------
@@ -106,31 +119,6 @@ class StateTraj:  # noqa: WPS214
             np.arange(self.nstates),
             self.states,
         )
-
-    @state_trajs.setter
-    def state_trajs(self, trajs):
-        """Set the state trajectory.
-
-        Parameters
-        ----------
-        trajs : list of ndarrays
-            List of ndarrays holding the input data.
-
-        """
-        self._trajs = mh.utils.format_state_traj(trajs)
-
-        # get number of states
-        self._states = mh.utils.unique(self._trajs)
-
-        # shift to indices
-        if not np.array_equal(self._states, np.arange(self.nstates)):
-            self._trajs, self._states = mh.utils.rename_by_index(
-                self._trajs,
-                return_permutation=True,
-            )
-
-        # set number of frames
-        self._nframes = np.sum([len(traj) for traj in self.trajs])
 
     @property
     def state_trajs_flatten(self):

--- a/src/msmhelper/statetraj.py
+++ b/src/msmhelper/statetraj.py
@@ -14,7 +14,7 @@ import msmhelper as mh
 class StateTraj:  # noqa: WPS214
     """Class for handling discrete state trajectories."""
 
-    # noqa: E800 # add slots magic,  self.__slots__ = ('_states', '_trajs').
+    __slots__ = ('_trajs', '_states')
     def __new__(cls, trajs):
         """Initialize new instance.
 
@@ -50,9 +50,6 @@ class StateTraj:  # noqa: WPS214
                 self._trajs,
                 return_permutation=True,
             )
-
-        # set number of frames
-        self._nframes = np.sum([len(traj) for traj in self.trajs])
 
     @property
     def states(self):
@@ -100,7 +97,7 @@ class StateTraj:  # noqa: WPS214
             Number of frames of all trajectories.
 
         """
-        return self._nframes
+        return np.sum([len(traj) for traj in self._trajs])
 
     @property
     def state_trajs(self):

--- a/src/msmhelper/statetraj.py
+++ b/src/msmhelper/statetraj.py
@@ -210,7 +210,12 @@ class StateTraj:  # noqa: WPS214
             Array with corresponding states.
 
         """
-        return mh.msm.estimate_markov_model(self, lagtime)
+        return mh.msm.msm._estimate_markov_model(
+            self.index_trajs,
+            lagtime,
+            self.nstates,
+            self.states,
+        )
 
     def state_to_idx(self, state):
         """Get idx corresponding to state.
@@ -477,7 +482,12 @@ class LumpedStateTraj(StateTraj):
 
         """
         # in the following corresponds 'i' to micro and 'a' to macro
-        msm_i, _ = mh.msm.estimate_markov_model(self, lagtime)
+        msm_i, _ = mh.msm.msm._estimate_markov_model(
+            self.microstate_index_trajs,
+            lagtime,
+            self.nmicrostates,
+            self.microstates,
+        )
         if not mh.utils.tests.is_ergodic(msm_i):
             raise TypeError('tmat needs to be ergodic transition matrix.')
         return (self._estimate_markov_model(msm_i), self.states)

--- a/src/msmhelper/statetraj.py
+++ b/src/msmhelper/statetraj.py
@@ -258,9 +258,9 @@ class LumpedStateTraj(StateTraj):
         return super().__new__(cls, None)
 
     def __init__(self, macrotrajs, microtrajs=None, positive=False):
-        """Initialize LumpedStateTraj and convert to index trajectories.
+        r"""Initialize LumpedStateTraj and convert to index trajectories.
 
-        If called with LumpedStateTraj instance, it will be retuned instead.
+        If called with LumpedStateTraj instance, it will be returned instead.
 
         Parameters
         ----------

--- a/test/test_statetraj.py
+++ b/test/test_statetraj.py
@@ -270,7 +270,7 @@ def test_LumpedStateTraj_estimate_markov_model(macro_traj):
     np.testing.assert_array_equal(states, states_ref)
 
     with pytest.raises(TypeError):
-        macrotraj = macro_traj.state_trajs_flatten
+        macrotraj = macro_traj.trajs_flatten
         microtraj = macro_traj.microstate_trajs_flatten
         microtraj[-1] = np.max(microtraj) + 1
         trap_traj = LumpedStateTraj(macrotraj, microtraj)

--- a/test/test_statetraj.py
+++ b/test/test_statetraj.py
@@ -205,6 +205,14 @@ def test_microstate_trajs(macrotraj, statetraj, indextraj):
         indextraj,
         macro_traj.microstate_trajs_flatten,
     )
+    np.testing.assert_array_equal(
+        indextraj,
+        macro_traj.microstate_index_trajs[0],
+    )
+    np.testing.assert_array_equal(
+        indextraj,
+        macro_traj.microstate_index_trajs_flatten,
+    )
 
 
 def test___eq__(state_traj, index_traj):

--- a/test/test_statetraj.py
+++ b/test/test_statetraj.py
@@ -276,6 +276,18 @@ def test_LumpedStateTraj_estimate_markov_model(macro_traj):
         trap_traj = LumpedStateTraj(macrotraj, microtraj)
         trap_traj.estimate_markov_model(tlag)
 
+    # enforce T_ij >= 0
+    macro_traj = LumpedStateTraj(
+        macro_traj.trajs,
+        macro_traj.microstate_trajs,
+        positive=True,
+    )
+
+    tmat, states = macro_traj.estimate_markov_model(tlag)
+    assert np.all(tmat >= 0)
+    np.testing.assert_array_almost_equal(tmat, tmat_ref)
+    np.testing.assert_array_equal(states, states_ref)
+
 
 @pytest.mark.parametrize('traj, state, idx, error', [
     ([1, 2, 4], 1, 0, None),

--- a/test/test_statetraj.py
+++ b/test/test_statetraj.py
@@ -195,9 +195,13 @@ def test_microstate_trajs(macrotraj, statetraj, indextraj):
         macro_traj.state_trajs_flatten,
     )
 
-    # check that state_trajs cannot be set unlike to StateTraj
+    # check that state_trajs cannot be set
     with pytest.raises(AttributeError):
         macro_traj.state_trajs = 5
+
+    # check that state_trajs cannot be set
+    with pytest.raises(AttributeError):
+        macro_traj.trajs = 5
 
     # check for index trajs
     macro_traj = LumpedStateTraj(macrotraj, indextraj)

--- a/test/test_statetraj.py
+++ b/test/test_statetraj.py
@@ -78,7 +78,7 @@ def test_StateTraj_constructor(statetraj):
     traj = StateTraj(statetraj)
     np.testing.assert_array_equal(
         statetraj,
-        traj.state_trajs[0],
+        traj.trajs[0],
     )
 
     # check if passing StateTraj returns object
@@ -93,7 +93,7 @@ def test_LumpedStateTraj_constructor(macrotraj, statetraj):
     traj = LumpedStateTraj(macrotraj, statetraj)
     np.testing.assert_array_equal(
         macrotraj,
-        traj.state_trajs[0],
+        traj.trajs[0],
     )
 
     np.testing.assert_array_equal(
@@ -138,11 +138,7 @@ def test_index_trajs(state_traj, index_traj):
     """Test index trajs property."""
     np.testing.assert_array_equal(
         index_traj.trajs,
-        index_traj.state_trajs,
-    )
-    np.testing.assert_array_equal(
-        state_traj.trajs,
-        state_traj.index_trajs,
+        index_traj.index_trajs,
     )
 
     with pytest.raises(AttributeError):
@@ -163,15 +159,15 @@ def test_trajs_flatten(state_traj, index_traj):
     )
 
 
-def test_state_trajs_flatten(state_traj, index_traj):
-    """Test flatten state trajectory."""
+def test_index_trajs_flatten(state_traj, index_traj):
+    """Test flatten index trajectory."""
     np.testing.assert_array_equal(
-        index_traj.state_trajs[0],
-        index_traj.state_trajs_flatten,
+        index_traj.index_trajs[0],
+        index_traj.index_trajs_flatten,
     )
     np.testing.assert_array_equal(
-        state_traj.state_trajs[0],
-        state_traj.state_trajs_flatten,
+        state_traj.index_trajs[0],
+        state_traj.index_trajs_flatten,
     )
 
 
@@ -188,16 +184,12 @@ def test_microstate_trajs(macrotraj, statetraj, indextraj):
     )
     np.testing.assert_array_equal(
         macrotraj,
-        macro_traj.state_trajs[0],
+        macro_traj.trajs[0],
     )
     np.testing.assert_array_equal(
         macrotraj,
-        macro_traj.state_trajs_flatten,
+        macro_traj.trajs_flatten,
     )
-
-    # check that state_trajs cannot be set
-    with pytest.raises(AttributeError):
-        macro_traj.state_trajs = 5
 
     # check that state_trajs cannot be set
     with pytest.raises(AttributeError):
@@ -207,18 +199,18 @@ def test_microstate_trajs(macrotraj, statetraj, indextraj):
     macro_traj = LumpedStateTraj(macrotraj, indextraj)
     np.testing.assert_array_equal(
         indextraj,
-        macro_traj.trajs[0],
+        macro_traj.microstate_trajs[0],
     )
     np.testing.assert_array_equal(
         indextraj,
-        macro_traj.trajs_flatten,
+        macro_traj.microstate_trajs_flatten,
     )
 
 
 def test___eq__(state_traj, index_traj):
     """Test eq method."""
     for traj in [state_traj, index_traj]:
-        assert StateTraj(traj.state_trajs) == traj
+        assert StateTraj(traj.trajs) == traj
 
     assert state_traj != index_traj
     assert state_traj != 5
@@ -227,7 +219,7 @@ def test___eq__(state_traj, index_traj):
 def test_LumpedStateTraj__eq__(macro_traj):
     """Test eq method."""
     assert LumpedStateTraj(
-        macro_traj.state_trajs, macro_traj.microstate_trajs,
+        macro_traj.trajs, macro_traj.microstate_trajs,
     ) == macro_traj
 
     assert macro_traj != LumpedStateTraj([0, 0], [1, 0])


### PR DESCRIPTION
Rewrite the two state trajectory classes:

- [x] Remove unclear `trajs` property
- [x] ~~Outsource the MSM estimation to the `msm.msm` module~~
- [x] Add parameter for `LumpedStateTraj` to enable enfrocing $T_{ij}\ge0$