### PR TITLE
Bump bugfix release of #30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
+### Bugfix 🐛:
+- Fix that `mh.LumpedStateTraj.index_trajs` and `mh.LumpedStateTraj.index_trajs_flatten` return now index trajectories corresponding to the macrostate trajectories
+
 ### Other changes:
 - Improve the x-axis limits, use more distinguishable colors, and lower the number of bins for the MD for the cli `msmhelper waiting-times`
 - Updated contribution and added maintenance guidelines
+- Minor improvements of docs suggested by JOSS reviewer
 
 
 ## [1.0.2] - 2023-03-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
+
+
+## [1.0.3] - 2023-04-17
 ### Bugfix 🐛:
 - Fix that `mh.LumpedStateTraj.index_trajs` and `mh.LumpedStateTraj.index_trajs_flatten` return now index trajectories corresponding to the macrostate trajectories
 
@@ -162,7 +165,8 @@ Chapman-Kolmogorov test
 - Initial release
 
 
-[Unreleased]: https://github.com/moldyn/msmhelper/compare/v1.0.2...main
+[Unreleased]: https://github.com/moldyn/msmhelper/compare/v1.0.3...main
+[1.0.3]: https://github.com/moldyn/msmhelper/compare/v1.0.2...v1.0.3
 [1.0.2]: https://github.com/moldyn/msmhelper/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/moldyn/msmhelper/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/moldyn/msmhelper/compare/v0.6.2...v1.0.0

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ README = remove_gh_dark_mode_only_tags(
 # This call to setup() does all the work
 setuptools.setup(
     name='msmhelper',
-    version='1.0.2',
+    version='1.0.3',
     description='Helper functions for Markov State Models.',
     long_description=README,
     long_description_content_type='text/markdown',

--- a/src/msmhelper/__init__.py
+++ b/src/msmhelper/__init__.py
@@ -30,4 +30,4 @@ from .utils import (
     unique,
 )
 
-__version__ = '1.0.2'
+__version__ = '1.0.3'

--- a/src/msmhelper/statetraj.py
+++ b/src/msmhelper/statetraj.py
@@ -423,6 +423,22 @@ class LumpedStateTraj(StateTraj):
         )
 
     @property
+    def index_trajs(self):
+        """Return index trajectory.
+
+        Returns
+        -------
+        trajs : list of ndarrays
+            List of ndarrays holding the input data.
+
+        """
+        return mh.shift_data(
+            self._trajs,
+            np.arange(self.nmicrostates),
+            self._state_assignment_idx,
+        )
+
+    @property
     def microstates(self):
         """Return active set of microstates.
 

--- a/test/test_statetraj.py
+++ b/test/test_statetraj.py
@@ -60,6 +60,15 @@ def macrotraj():
 
 
 @pytest.fixture
+def macro_indextraj():
+    """Define state trajectory."""
+    return np.array(
+        [0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1],
+        dtype=np.int32,
+    )
+
+
+@pytest.fixture
 def macro_traj():
     """Define index trajectory."""
     traj = np.array(
@@ -145,6 +154,18 @@ def test_index_trajs(state_traj, index_traj):
         state_traj.trajs = 5
     with pytest.raises(AttributeError):
         state_traj.index_trajs = 5
+
+
+def test_macroindex_trajs(macro_traj, indextraj, macro_indextraj):
+    """Test index trajs property."""
+    np.testing.assert_array_equal(
+        macro_traj.index_trajs_flatten,
+        macro_indextraj,
+    )
+    np.testing.assert_array_equal(
+        macro_traj.microstate_index_trajs_flatten,
+        indextraj,
+    )
 
 
 def test_trajs_flatten(state_traj, index_traj):


### PR DESCRIPTION
Fix #30, so that  `mh.LumpedStateTraj.index_trajs` and  `mh.LumpedStateTraj.index_trajs_flatten` return now the macrostate index trajectories.